### PR TITLE
Configure API and local server settings

### DIFF
--- a/src/main/java/com/solesonic/izzybot/api/atlassian/JiraAuthController.java
+++ b/src/main/java/com/solesonic/izzybot/api/atlassian/JiraAuthController.java
@@ -9,7 +9,7 @@ import org.springframework.web.bind.annotation.RequestParam;
 import org.springframework.web.bind.annotation.RestController;
 
 @RestController
-@RequestMapping("/izzybot/atlassian")
+@RequestMapping("/atlassian")
 public class JiraAuthController {
     private final JiraAuthService jiraAuthService;
 

--- a/src/main/java/com/solesonic/izzybot/api/chat/ChatController.java
+++ b/src/main/java/com/solesonic/izzybot/api/chat/ChatController.java
@@ -19,7 +19,7 @@ import java.util.List;
 import java.util.UUID;
 
 @RestController
-@RequestMapping("/izzybot/chats")
+@RequestMapping("/chats")
 public class ChatController {
     private static final Logger log = LoggerFactory.getLogger(ChatController.class);
 

--- a/src/main/java/com/solesonic/izzybot/api/ollama/DocumentController.java
+++ b/src/main/java/com/solesonic/izzybot/api/ollama/DocumentController.java
@@ -14,7 +14,7 @@ import java.net.URI;
 import java.util.List;
 
 @RestController
-@RequestMapping("/izzybot/documents")
+@RequestMapping("/documents")
 public class DocumentController {
 
     private final VectorStoreService vectorStoreService;

--- a/src/main/java/com/solesonic/izzybot/api/ollama/OllamaController.java
+++ b/src/main/java/com/solesonic/izzybot/api/ollama/OllamaController.java
@@ -9,7 +9,7 @@ import java.util.List;
 import java.util.UUID;
 
 @RestController
-@RequestMapping("/izzybot/ollama")
+@RequestMapping("/ollama")
 public class OllamaController {
     private final OllamaService ollamaService;
 

--- a/src/main/java/com/solesonic/izzybot/api/ollama/TrainingDocumentController.java
+++ b/src/main/java/com/solesonic/izzybot/api/ollama/TrainingDocumentController.java
@@ -12,7 +12,7 @@ import org.springframework.web.bind.annotation.RestController;
 import java.util.List;
 
 @RestController
-@RequestMapping("/izzybot")
+@RequestMapping("")
 public class TrainingDocumentController {
     private static final Logger log = LoggerFactory.getLogger(TrainingDocumentController.class);
 

--- a/src/main/java/com/solesonic/izzybot/api/user/UserController.java
+++ b/src/main/java/com/solesonic/izzybot/api/user/UserController.java
@@ -16,7 +16,7 @@ import java.net.URI;
 import java.util.UUID;
 
 @RestController
-@RequestMapping("/izzybot/users")
+@RequestMapping("/users")
 public class UserController {
     private final UserPreferencesService userPreferencesService;
 

--- a/src/main/java/com/solesonic/izzybot/security/local/LocalJwtUserRequestFilter.java
+++ b/src/main/java/com/solesonic/izzybot/security/local/LocalJwtUserRequestFilter.java
@@ -11,6 +11,7 @@ import jakarta.servlet.http.HttpServletResponse;
 import org.apache.commons.collections4.CollectionUtils;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
+import org.springframework.beans.factory.annotation.Value;
 import org.springframework.context.annotation.Profile;
 import org.springframework.core.annotation.Order;
 import org.springframework.security.core.Authentication;
@@ -28,6 +29,11 @@ import java.util.UUID;
 @Profile({"test", "local"})
 public class LocalJwtUserRequestFilter extends OncePerRequestFilter {
     private static final Logger log = LoggerFactory.getLogger(LocalJwtUserRequestFilter.class);
+    public static final String ISS = "iss";
+
+    @Value("${spring.security.oauth2.resourceserver.jwt.issuer-uri}")
+    private String issuerUri;
+
     public static final String SUB = "sub";
     private final UserRequestContext userRequestContext;
 
@@ -49,9 +55,9 @@ public class LocalJwtUserRequestFilter extends OncePerRequestFilter {
 
         //If running the UI locally there will be an authentication
         if (authentication != null && authentication.getPrincipal() instanceof Jwt jwt) {
-            String issuer = jwt.getClaimAsString("iss");
+            String issuer = jwt.getClaimAsString(ISS);
 
-            if("https://cognito-idp.us-east-1.amazonaws.com/us-east-1_nfFx3zaKg".equalsIgnoreCase(issuer)) {
+            if(issuerUri.equalsIgnoreCase(issuer)) {
                 //This is direct from Oauth2
                 userId = defaultUserId();
             } else {

--- a/src/main/resources/application-local.properties
+++ b/src/main/resources/application-local.properties
@@ -1,4 +1,4 @@
-server.address=0.0.0.0
+server.address=localhost
 server.port=8080
 
 logging.level.org.springframework.security=DEBUG

--- a/src/main/resources/application-local.properties
+++ b/src/main/resources/application-local.properties
@@ -36,3 +36,9 @@ spring.ai.vectorstore.pgvector.initialize-schema=false
 
 spring.servlet.multipart.max-file-size=20MB
 spring.servlet.multipart.max-request-size=20MB
+
+management.endpoints.web.exposure.include=env,configprops
+management.endpoint.env.show-values=ALWAYS
+management.endpoint.configprops.show-values=ALWAYS
+
+

--- a/src/main/resources/application.properties
+++ b/src/main/resources/application.properties
@@ -2,6 +2,8 @@ spring.config.import=optional:file:.env[.properties]
 
 spring.application.name=Solesonic LLM API
 
+server.servlet.context-path=/${BASE_URI}
+
 spring.datasource.url=${SPRING_DATASOURCE_URI}
 spring.datasource.username=${SPRING_DATASOURCE_USERNAME}
 spring.datasource.password=${SPRING_DATASOURCE_PASSWORD}


### PR DESCRIPTION
### Updates to support local development

This pull request updates the following:

- Configures the local server to bind to `localhost` and uses the issuer URI from application properties in `LocalJwtUserRequestFilter`.
- Removes the `/izzybot` prefix from API endpoints and updates application properties accordingly.
