### PR TITLE
Externalize Jira configurations into properties

### DIFF
--- a/src/main/java/com/solesonic/exception/GlobalExceptionHandler.java
+++ b/src/main/java/com/solesonic/exception/GlobalExceptionHandler.java
@@ -7,6 +7,7 @@ import com.solesonic.scope.UserRequestContext;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 import org.springframework.ai.chat.messages.MessageType;
+import org.springframework.beans.factory.annotation.Value;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.ControllerAdvice;
@@ -17,11 +18,12 @@ import javax.validation.constraints.NotNull;
 import java.net.URI;
 import java.util.UUID;
 
-import static com.solesonic.tools.jira.CreateJiraTools.JIRA_URL_TEMPLATE;
-
 @ControllerAdvice
 public class GlobalExceptionHandler {
     private static final Logger log = LoggerFactory.getLogger(GlobalExceptionHandler.class);
+
+    @Value("${JIRA_URL_TEMPLATE}")
+    private String jiraUrlTemplate;
 
     private static final String DUPLICATE_JIRA_MESSAGE_TEMPLATE = """
             I've gone into an error state but still managed managed to create your Jira issue.
@@ -78,7 +80,7 @@ public class GlobalExceptionHandler {
     @ExceptionHandler(DuplicateJiraCreationException.class)
     public ResponseEntity<SolesonicChatResponse> handleDuplicateJiraException(DuplicateJiraCreationException duplicateJiraCreationException) {
         JiraIssue jiraIssue = duplicateJiraCreationException.getJiraIssue();
-        String jiraUri = JIRA_URL_TEMPLATE.replace(ISSUE_ID, jiraIssue.key());
+        String jiraUri = jiraUrlTemplate.replace(ISSUE_ID, jiraIssue.key());
 
         String responseMessage = DUPLICATE_JIRA_MESSAGE_TEMPLATE.replace(ISSUE_LINK, jiraUri);
 

--- a/src/main/java/com/solesonic/service/atlassian/JiraService.java
+++ b/src/main/java/com/solesonic/service/atlassian/JiraService.java
@@ -6,6 +6,7 @@ import com.solesonic.model.atlassian.jira.issue.User;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 import org.springframework.beans.factory.annotation.Qualifier;
+import org.springframework.beans.factory.annotation.Value;
 import org.springframework.core.ParameterizedTypeReference;
 import org.springframework.stereotype.Service;
 import org.springframework.web.reactive.function.client.WebClient;
@@ -25,7 +26,9 @@ public class JiraService {
     public static final String PROJECT_ID = "10000";
     public static final String ISSUE_TYPE_ID = "10001";
 
-    public static final String CLOUD_ID_PATH = "c89568e3-77f7-425f-918a-32e3b30734fd";
+    @Value("${solesonic.llm.jira.cloud.id.path")
+    private String cloudIdPath;
+
     public static final String EX = "ex";
     public static final String JIRA = "jira";
 
@@ -35,7 +38,8 @@ public class JiraService {
     public static final String API_PATH = "api";
     public static final String VERSION_PATH = "3";
 
-    public static final String[] basePathSegments = {EX, JIRA, CLOUD_ID_PATH, REST_PATH, API_PATH, VERSION_PATH};
+    public final String[] basePathSegments = {EX, JIRA, cloudIdPath, REST_PATH, API_PATH, VERSION_PATH};
+
     public static final String ISSUE_PATH = "issue";
     private final WebClient webClient;
 

--- a/src/main/java/com/solesonic/tools/jira/CreateJiraTools.java
+++ b/src/main/java/com/solesonic/tools/jira/CreateJiraTools.java
@@ -1,12 +1,12 @@
 package com.solesonic.tools.jira;
 
 import com.solesonic.model.atlassian.jira.issue.*;
-import com.solesonic.model.atlassian.jira.issue.*;
 import com.solesonic.service.atlassian.JiraService;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 import org.springframework.ai.tool.annotation.Tool;
 import org.springframework.ai.tool.annotation.ToolParam;
+import org.springframework.beans.factory.annotation.Value;
 import org.springframework.stereotype.Component;
 
 import java.util.ArrayList;
@@ -21,7 +21,9 @@ public class CreateJiraTools {
     private static final Logger log = LoggerFactory.getLogger(CreateJiraTools.class);
 
     public static final String CREATE_JIRA_ISSUE = "create_jira_issue";
-    public static final String JIRA_URL_TEMPLATE = "https://solesonic-llm-api.atlassian.net/browse/{issueId}";
+
+    @Value("${JIRA_URL_TEMPLATE}")
+    private String jiraUrlTemplate;
 
     private final JiraService jiraService;
 
@@ -106,7 +108,7 @@ public class CreateJiraTools {
 
         log.debug("Created jira issue: {}", created);
 
-        String jiraUri = JIRA_URL_TEMPLATE.replace("{issueId}", created.key());
+        String jiraUri = jiraUrlTemplate.replace("{issueId}", created.key());
 
         log.debug("Using jira uri: {}", jiraUri);
 

--- a/src/main/resources/META-INF/additional-spring-configuration-metadata.json
+++ b/src/main/resources/META-INF/additional-spring-configuration-metadata.json
@@ -59,6 +59,16 @@
       "name": "solesonic.llm.bot.name",
       "type": "java.lang.String",
       "description": "The name of the bot."
+    },
+    {
+      "name": "solesonic.llm.jira.url.template",
+      "type": "java.lang.String",
+      "description": "URL template for linking jira issues."
+    },
+    {
+      "name": "solesonic.llm.jira.cloud.id.path",
+      "type": "java.lang.String",
+      "description": "The path to the Jira Cloud ID."
     }
   ]
 }

--- a/src/main/resources/application.properties
+++ b/src/main/resources/application.properties
@@ -47,3 +47,6 @@ logging.level.io.modelcontextprotocol.client=DEBUG
 logging.level.io.modelcontextprotocol.spec=DEBUG
 
 solesonic.llm.bot.name=${BOT_NAME:solesonic-llm-api}
+
+solesonic.llm.jira.url.template=${JIRA_URL_TEMPLATE:https://solesonic-llm-api.atlassian.net/browse/{issueId}
+solesonic.llm.jira.cloud.id.path=${JIRA_CLOUD_ID_PATH:yourCloudId}


### PR DESCRIPTION
This pull request externalizes Jira URL and Cloud ID configurations into properties to enhance flexibility and simplify configuration management. This change supports easier updates and better alignment with varying environments.