### PR TITLE
Add token exchange for OBO to MCP for UI clients

### DIFF
--- a/src/main/java/com/solesonic/mcp/client/TokenExchangeService.java
+++ b/src/main/java/com/solesonic/mcp/client/TokenExchangeService.java
@@ -1,0 +1,49 @@
+package com.solesonic.mcp.client;
+
+import com.fasterxml.jackson.databind.JsonNode;
+import org.springframework.beans.factory.annotation.Qualifier;
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.stereotype.Service;
+import org.springframework.web.reactive.function.BodyInserters;
+import org.springframework.web.reactive.function.client.WebClient;
+import reactor.core.publisher.Mono;
+
+import static com.solesonic.mcp.client.config.TokenExchangeClientConfig.MCP_TOKEN_EXCHANGE_CLIENT;
+
+@Service
+public class TokenExchangeService {
+    public static final String TOKEN_EXCHANGE_GRANT_TYPE = "urn:ietf:params:oauth:grant-type:token-exchange";
+    public static final String GRANT_TYPE = "grant_type";
+    public static final String CLIENT_ID = "client_id";
+    public static final String CLIENT_SECRET = "client_secret";
+    public static final String SUBJECT_TOKEN = "subject_token";
+    public static final String TOKEN_TYPE_ACCESS_TOKEN = "urn:ietf:params:oauth:token-type:access_token";
+    public static final String REQUESTED_TOKEN_TYPE = "requested_token_type";
+    public static final String ACCESS_TOKEN = "access_token";
+
+
+    private final WebClient tokenExchangeClient;
+
+    @Value("${solesonic.llm.token.exchange.client-id}")
+    private String tokenExchangeClientId;
+
+    @Value("${solesonic.llm.token.exchange.client-secret}")
+    private String tokenExchangeClientSecret;
+
+    public TokenExchangeService(@Qualifier(MCP_TOKEN_EXCHANGE_CLIENT) WebClient tokenExchangeClient) {
+        this.tokenExchangeClient = tokenExchangeClient;
+    }
+
+    public Mono<String> exchangeToken(String subjectToken) {
+        return tokenExchangeClient.post()
+                .body(BodyInserters.fromFormData(GRANT_TYPE, TOKEN_EXCHANGE_GRANT_TYPE)
+                        .with(CLIENT_ID, tokenExchangeClientId)
+                        .with(CLIENT_SECRET, tokenExchangeClientSecret)
+                        .with(SUBJECT_TOKEN, subjectToken)
+                        .with(REQUESTED_TOKEN_TYPE, TOKEN_TYPE_ACCESS_TOKEN))
+                .retrieve()
+                .bodyToMono(JsonNode.class)
+                .map(json -> json.get(ACCESS_TOKEN).asText())
+                .switchIfEmpty(Mono.error(new IllegalStateException("Token exchange returned no access_token")));
+    }
+}

--- a/src/main/java/com/solesonic/mcp/client/config/TokenExchangeClientConfig.java
+++ b/src/main/java/com/solesonic/mcp/client/config/TokenExchangeClientConfig.java
@@ -1,0 +1,26 @@
+package com.solesonic.mcp.client.config;
+
+import org.springframework.beans.factory.annotation.Qualifier;
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.http.MediaType;
+import org.springframework.web.reactive.function.client.WebClient;
+
+@Configuration
+public class TokenExchangeClientConfig {
+
+    public static final String MCP_TOKEN_EXCHANGE_CLIENT = "mcp-token-exchange-client";
+
+    @Value("${solesonic.llm.token.exchange.endpoint}")
+    private String tokenExchangeEndpoint;
+
+    @Bean
+    @Qualifier(MCP_TOKEN_EXCHANGE_CLIENT)
+    public WebClient tokenExchangeWebClient() {
+        return WebClient.builder()
+                .baseUrl(tokenExchangeEndpoint)
+                .defaultHeaders(headers -> headers.setContentType(MediaType.APPLICATION_FORM_URLENCODED))
+                .build();
+    }
+}

--- a/src/main/resources/application-local.properties
+++ b/src/main/resources/application-local.properties
@@ -44,7 +44,7 @@ management.endpoint.configprops.show-values=ALWAYS
 
 solesonic.llm.intent.model=qwen2.5:7b
 
-spring.ai.mcp.client.enabled=false
+spring.ai.mcp.client.enabled=true
 
 training.task.enabled=false
 confluence.training.task.enabled=false

--- a/src/main/resources/application.properties
+++ b/src/main/resources/application.properties
@@ -19,6 +19,10 @@ confluence.training.task.enabled=true
 spring.security.oauth2.resourceserver.jwt.issuer-uri=${ISSUER_URI}
 spring.security.oauth2.resourceserver.jwt.jwk-set-uri=${JWK_SET_URI}
 
+solesonic.llm.token.exchange.client-id=${MCP_CLIENT_ID}
+solesonic.llm.token.exchange.client-secret=${MCP_CLIENT_SECRET}
+solesonic.llm.token.exchange.endpoint=${TOKEN_ENDPOINT}
+
 spring.ai.vectorstore.pgvector.table-name=vector_store
 
 spring.flyway.enabled=true


### PR DESCRIPTION
This PR implements a token‑exchange flow that allows authenticated UI clients to request MCP tokens on behalf of a user. The new functionality supports the OBO (On‑Behalf‑Of) grant type, enabling seamless access to MCP resources from the UI.